### PR TITLE
Update Install-AXAgentMSI.ps1

### DIFF
--- a/Scripts/Install-AXAgentMSI.ps1
+++ b/Scripts/Install-AXAgentMSI.ps1
@@ -54,7 +54,6 @@
   Changes:
     - Added functionality to restart the amagent service if it is not running
     - Before installing the agent, we will check if console.automox.com can be reached
-    - Added functionality to rotate the log file if it exceeds 1MB
     - This script will use Start-Transcript to log the installation process
 
 .EXAMPLE
@@ -127,7 +126,7 @@ function DownloadAndInstall-AxAgent
         [Parameter(Mandatory = $true)][String]$AccessKey
     )
 
-    # Step 2: Download the installer
+    # Step 1: Download the installer
     Write-Output "Downloading started..."
     $downloader = New-Object System.Net.WebClient
     try 
@@ -141,7 +140,7 @@ function DownloadAndInstall-AxAgent
         exit 1
     }
 
-    # Step 3: Install the agent
+    # Step 2: Install the agent
     Write-Output "Starting installation of $installerPath"
     $process = Start-Process 'msiexec.exe' -ArgumentList "/i `"$installerPath`" /qn /norestart ACCESSKEY=$AccessKey" -Wait -PassThru
     Write-Output "Installation completed with Exit Code $($process.ExitCode)"
@@ -201,7 +200,7 @@ else
     {
         Write-Error "Automox Console is not reachable. Exiting script without making changes."
         Stop-Transcript
-        exit 1
+        Exit 1
     }
     $exitCode = DownloadAndInstall-AxAgent -installerUrl $installerUrl -installerPath $installerPath -AccessKey $AccessKey
 }

--- a/Scripts/Install-AXAgentMSI.ps1
+++ b/Scripts/Install-AXAgentMSI.ps1
@@ -244,7 +244,8 @@ elseif (($null -ne $agentInstalled) -and ($service.Status -ne "Running"))
 ### Check if $exitCode is valid (not null, empty, or whitespace)
 ### If an error is encountered, we will exit the script without setting groups ###
 if (-not [String]::IsNullOrEmpty($exitCode) -and -not [String]::IsNullOrWhiteSpace($exitCode)) {
-    Switch ($exitCode) {
+    Switch ($exitCode) 
+    {
         {($_ -in @('0', '1641', '3010'))} {
             Write-Output "Download and installation process completed successfully" 
             # If successful installation (based on exit code), then proceed to set the group.
@@ -268,9 +269,16 @@ if (-not [String]::IsNullOrEmpty($exitCode) -and -not [String]::IsNullOrWhiteSpa
             }
         }
 
-        Default {
+        Default
+        {
             if ([string]::IsNullOrEmpty($GroupName) -and [string]::IsNullOrEmpty($ParentGroupName)) {
                 Write-Output "No Group or Parent Group specified. Device will remain in Default Group." 
+                Write-Output "Installation Script has finished successfully. Exit Code 0" 
+                Stop-Transcript
+                Exit 0
+            } elseif (-not [string]::IsNullOrEmpty($ParentGroupName) -and -not [string]::IsNullOrEmpty($GroupName)) {
+                Write-Output "Moving Device to Group: $GroupName under Parent Group: $ParentGroupName" 
+                Set-AxServerGroup -GroupName $GroupName -ParentGroup $ParentGroupName
                 Write-Output "Installation Script has finished successfully. Exit Code 0" 
                 Stop-Transcript
                 Exit 0
@@ -287,8 +295,10 @@ if (-not [String]::IsNullOrEmpty($exitCode) -and -not [String]::IsNullOrWhiteSpa
                 exit $exitCode
             }
         }
+        }
     }
-} else {
+else 
+{
     Write-Output "Installation was not required. Script Exiting without errors"
     Stop-Transcript
     exit 0

--- a/Scripts/Install-AXAgentMSI.ps1
+++ b/Scripts/Install-AXAgentMSI.ps1
@@ -215,6 +215,7 @@ if ($service.Status -eq "Running" -and $agentInstalled)
 {
     Write-Output "Agent Service is installed and Running."
     Write-Output "Script Completed Successfully... Exiting"
+    Stop-Transcript
     Exit 0
 }
 elseif (($null -ne $agentInstalled) -and ($service.Status -ne "Running"))
@@ -229,6 +230,7 @@ elseif (($null -ne $agentInstalled) -and ($service.Status -ne "Running"))
         catch
         {
             Write-Error "Service failed to start. Attempting to restart the service"
+            Stop-Transcript
             Exit 1
         }
 }
@@ -251,6 +253,7 @@ Switch (([String]::IsNullOrEmpty($exitCode) -eq $False) -and ([String]::IsNullOr
                     Write-Output "Moving Device to Group: $GroupName under Parent Group: $ParentGroupName" 
                     Set-AxServerGroup -GroupName $GroupName -ParentGroup $ParentGroupName
                     Write-Output "Installation Script has finished successfully. Exit Code 0" 
+                    Stop-Transcript
                     Exit 0
                 }
                 elseif (-not [string]::IsNullOrEmpty($GroupName))
@@ -258,12 +261,14 @@ Switch (([String]::IsNullOrEmpty($exitCode) -eq $False) -and ([String]::IsNullOr
                     Write-Output "Moving Device to Group: $GroupName" 
                     Set-AxServerGroup -GroupName $GroupName
                     Write-Output "Installation Script has finished successfully. Exit Code 0" 
+                    Stop-Transcript
                     Exit 0
                 }
                 else
                 {
                     Write-Output "No Group was specified. Device will remain in Default Group" 
                     Write-Output "Installation Script has finished successfully. Exit Code 0" 
+                    Stop-Transcript
                     Exit 0
                 }
             }
@@ -274,12 +279,14 @@ Switch (([String]::IsNullOrEmpty($exitCode) -eq $False) -and ([String]::IsNullOr
                 {
                     Write-Output "No Group or Parent Group specified. Device will remain in Default Group." 
                     Write-Output "Installation Script has finished successfully. Exit Code 0" 
+                    Stop-Transcript
                     Exit 0
                 }
                 else
                 {
                     Write-Output "The Automox Agent was installed, but failed to set the desired group."
                     Write-Error "Please check that your specified group or parent group exist in the Automox Console."
+                    Stop-Transcript
                     exit $exitCode
                 }
             }
@@ -289,9 +296,9 @@ Switch (([String]::IsNullOrEmpty($exitCode) -eq $False) -and ([String]::IsNullOr
     Default
     {
         Write-Output "Installation was not required. Script Exiting without errors"
+        Stop-Transcript
         exit 0
     }
 }
 
-Stop-Transcript
 ##################### Main Script End #####################

--- a/Scripts/Install-AXAgentMSI.ps1
+++ b/Scripts/Install-AXAgentMSI.ps1
@@ -148,7 +148,6 @@ function DownloadAndInstall-AxAgent
     # Step 2: Install the agent
     Write-Output "Starting installation of $installerPath"
     $process = Start-Process 'msiexec.exe' -ArgumentList "/i `"$installerPath`" /qn /norestart ACCESSKEY=$AccessKey" -Wait -PassThru
-    Write-Output "Installation completed with Exit Code $($process.ExitCode)"
 
     # Return the exit code
     return $process.ExitCode
@@ -208,6 +207,7 @@ else
         Exit 1
     }
     $exitCode = DownloadAndInstall-AxAgent -installerUrl $installerUrl -installerPath $installerPath -AccessKey $AccessKey
+    Write-Output "Installation completed with Exit Code $exitCode"
 }
 
 

--- a/Scripts/Install-AXAgentMSI.ps1
+++ b/Scripts/Install-AXAgentMSI.ps1
@@ -80,11 +80,16 @@ $installerName = "Automox_Installer-latest.msi"
 $installerPath = "${env:TEMP}\${installerName}"
 $agentPath = "${env:ProgramFiles(x86)}\Automox\amagent.exe"
 $logFile = "${env:TEMP}\AutomoxInstallandLaunch.log"
+$VerbosePreference = "Continue"
 
 #################### Region end: Setup Variables #################
 
 # Start the transcript
 Start-Transcript -Path $logFile -Append
+
+# Write a start time to the transcript
+$Date = Get-Date
+Write-Verbose "Automox Installation Transcript begin: $Date"
 
 #################### Region start: Functions #################
 


### PR DESCRIPTION
Hello all! 

This is mostly a general re-write as some of this code seems to be from several years ago. 

Some changes were made to this script for Quality of life improvements. The main issue we were aiming to resolve is that the current version of this script will fail/exit if the Automox service exists. However,  uninstalling the agent leaves a lingering "service" causing this script to fail even if the agent is not installed.

This script functions like so:

If the agent is not installed:
- We will check that console.automox.com can be reached. We will exit if we cannot reach the console.
- Download and Install the agent. (If this fails we exit without attempting to set groups.)
- If the exit code for the installer is successful, we will add the device to the groups specified.
  - (An improvement was made here, if no groups are specified we will log that the device was placed in Default)

If the agent is already installed, we will:
- Check if the agent’s service is running. If not we will attempt to restart it.
- If the agent cannot start, we report this to the log file and provide a link to some troubleshooting documentation

Lastly, functionality to rotate the log was added if it exceeds 1MB.